### PR TITLE
Keep listener running in GUI mode, Improved TCP handling

### DIFF
--- a/src/tmtccmd/core/backend.py
+++ b/src/tmtccmd/core/backend.py
@@ -307,8 +307,6 @@ class TmTcHandler(BackendBase):
                 LOGGER.error("Custom mode handling module not provided!")
 
     def __core_operation(self, one_shot: bool):
-        if self.mode == CoreModeList.LISTENER_MODE:
-            one_shot = False
         if not one_shot:
             while True:
                 self.__handle_action()

--- a/src/tmtccmd/core/frontend.py
+++ b/src/tmtccmd/core/frontend.py
@@ -217,7 +217,7 @@ class TmTcFrontend(QMainWindow, FrontendBase):
 
     def __start_seq_cmd_op(self):
         if self.__debug_mode:
-            LOGGER.info("Start Service Test Button pressed.")
+            LOGGER.info("Send command button pressed.")
         if not self.__get_send_button():
             return
         self.__set_send_button(False)

--- a/src/tmtccmd/core/frontend.py
+++ b/src/tmtccmd/core/frontend.py
@@ -82,43 +82,50 @@ class WorkerOperationsCodes(enum.IntEnum):
     DISCONNECT = 0
     SEQUENTIAL_COMMANDING = 1
     LISTENING = 2
+    IDLE = 4
 
 
 class WorkerThread(QObject):
-    finished = pyqtSignal()
-    sequential_commanding_finished = pyqtSignal()
+    disconnected = pyqtSignal()
+    command_executed = pyqtSignal()
 
     def __init__(self, op_code: WorkerOperationsCodes, tmtc_handler: TmTcHandler):
         super(QObject, self).__init__()
         self.op_code = op_code
         self.tmtc_handler = tmtc_handler
+        self.tmtc_handler.one_shot_operation = True
 
     def set_op_code(self, op_code: WorkerOperationsCodes):
         self.op_code = op_code
 
     def run_worker(self):
-        if self.op_code == WorkerOperationsCodes.DISCONNECT:
-            self.tmtc_handler.close_listener()
-            while True:
-                if not self.tmtc_handler.is_com_if_active():
-                    break
-                else:
-                    time.sleep(0.4)
-            self.finished.emit()
-        elif self.op_code == WorkerOperationsCodes.SEQUENTIAL_COMMANDING:
-            self.tmtc_handler.set_mode(CoreModeList.SEQUENTIAL_CMD_MODE)
-            self.tmtc_handler.one_shot_operation = True
-            # It is expected that the TMTC handler is in the according state to perform the
-            # operation
-            self.tmtc_handler.perform_operation()
-            self.sequential_commanding_finished.emit()
-            self.op_code = WorkerOperationsCodes.LISTENING
-        elif self.op_code == WorkerOperationsCodes.LISTENING:
-            self.tmtc_handler.set_mode(CoreModeList.LISTENER_MODE)
-            self.tmtc_handler.perform_operation()
-        else:
-            LOGGER.warning("Unknown worker operation code!")
-            self.finished.emit()
+        while True:
+            op_code = self.op_code
+            if op_code == WorkerOperationsCodes.DISCONNECT:
+                self.tmtc_handler.close_listener()
+                while True:
+                    if not self.tmtc_handler.is_com_if_active():
+                        break
+                    else:
+                        time.sleep(0.4)
+                self.op_code = WorkerOperationsCodes.IDLE
+                self.disconnected.emit()
+            elif op_code == WorkerOperationsCodes.SEQUENTIAL_COMMANDING:
+                self.tmtc_handler.one_shot_operation = True
+                # It is expected that the TMTC handler is in the according state to perform the
+                # operation
+                self.tmtc_handler.perform_operation()
+                self.op_code = WorkerOperationsCodes.LISTENING
+                self.command_executed.emit()
+            elif op_code == WorkerOperationsCodes.LISTENING:
+                self.tmtc_handler.one_shot_operation = True
+                self.tmtc_handler.set_mode(CoreModeList.LISTENER_MODE)
+                self.tmtc_handler.perform_operation()
+            elif op_code == WorkerOperationsCodes.IDLE:
+                pass
+            else:
+                # This must be a programming error
+                LOGGER.error("Unknown worker operation code {0}!".format(self.op_code))
 
 
 class RunnableThread(QRunnable):
@@ -154,7 +161,7 @@ class TmTcFrontend(QMainWindow, FrontendBase):
 
         self.__worker = None
         self.__thread = None
-        self.__debug_mode = False
+        self.__debug_mode = True
 
         self.__combo_box_op_codes: Union[None, QComboBox] = None
         module_path = os.path.abspath(config_module.__file__).replace("__init__.py", "")
@@ -216,10 +223,9 @@ class TmTcFrontend(QMainWindow, FrontendBase):
         self.__set_send_button(False)
         self._tmtc_handler.set_service(self._current_service)
         self._tmtc_handler.set_opcode(self._current_op_code)
-        self.__start_qthread_task(
-            op_code=WorkerOperationsCodes.SEQUENTIAL_COMMANDING,
-            finish_callback=self.__finish_seq_cmd_op,
-        )
+        self._tmtc_handler.set_mode(CoreModeList.SEQUENTIAL_CMD_MODE)
+        self.__worker.set_op_code(WorkerOperationsCodes.SEQUENTIAL_COMMANDING)
+        self.__worker.command_executed.connect(self.__finish_seq_cmd_op)
 
     def __finish_seq_cmd_op(self):
         self.__set_send_button(True)
@@ -245,10 +251,7 @@ class TmTcFrontend(QMainWindow, FrontendBase):
             LOGGER.info("Closing TM listener..")
             self.__command_button.setEnabled(False)
             self.__connect_button.setEnabled(False)
-            self.__start_qthread_task(
-                op_code=WorkerOperationsCodes.DISCONNECT,
-                finish_callback=self.__finish_disconnect_button_op,
-            )
+            self.__worker.set_op_code(WorkerOperationsCodes.DISCONNECT)
 
     def __finish_disconnect_button_op(self):
         self.__connect_button.setEnabled(True)
@@ -422,16 +425,9 @@ class TmTcFrontend(QMainWindow, FrontendBase):
         self.__thread = QThread()
         self.__worker = WorkerThread(op_code=op_code, tmtc_handler=self._tmtc_handler)
         self.__worker.moveToThread(self.__thread)
-
         self.__thread.started.connect(self.__worker.run_worker)
-        self.__worker.finished.connect(self.__thread.quit)
-        self.__worker.finished.connect(self.__worker.deleteLater)
-        self.__thread.finished.connect(self.__thread.deleteLater)
         self.__thread.start()
-
-    def __send_commands(self, finish_callback):
-        self.__worker.set_op_code()
-        self.__worker.sequential_commanding_finished.connect(finish_callback)
+        self.__worker.disconnected.connect(self.__finish_disconnect_button_op)
 
     @staticmethod
     def __add_vertical_separator(grid: QGridLayout, row: int):

--- a/src/tmtccmd/sendreceive/sequential_sender_receiver.py
+++ b/src/tmtccmd/sendreceive/sequential_sender_receiver.py
@@ -181,6 +181,8 @@ class SequentialCommandSenderReceiver(CommandSenderReceiver):
         # Queue empty. Can happen because a wait period might still be ongoing
         if not self._tc_queue:
             return False
+        if self.wait_period_ongoing():
+            return False
         tc_queue_tuple = self._tc_queue.pop()
         if self.check_queue_entry(tc_queue_tuple):
             self._start_time = time.time()

--- a/src/tmtccmd/sendreceive/sequential_sender_receiver.py
+++ b/src/tmtccmd/sendreceive/sequential_sender_receiver.py
@@ -200,7 +200,7 @@ class SequentialCommandSenderReceiver(CommandSenderReceiver):
 
         # queue empty.
         elif not self._tc_queue:
-            # Another specal case: Last queue entry is to wait.
+            # Another special case: Last queue entry is to wait.
             if self._wait_period > 0:
                 if self.wait_period_ongoing():
                     return False


### PR DESCRIPTION
GUI:
* until now it was not able to keep the listener running when using the GUI mode which leads to a full TC queue
* the frontend has been adapted in a way that the mode is changed to listener mode as soon as the sending of a command sequence is finished

TCP client:
* when keeping the socket active while the OBSW acting as the TCP server has been stopped, relaunching the OBSW could result in the TCP error indicating the IP address is already in use
* the change in the TCP Com IF ensures that the client detects the shutdown of the server and also closes its socket
* this prevents the OBSW from running in the "address in use" error

Wait command in command_sender_and_receiver:
* a wait command was executed only when placed at the last position in the command queue
* wait commands are now also considered when inserted between two telecommands